### PR TITLE
Enhancements for floating point comparisons

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Whats new in FCTX 1.6.2
 -----------------------
 
  - ENH: fct_chk_eq_dbl and fct_chk_neq_dbl show more digits on failure.
+ - ENH: fct_chk_eqtol_dbl and fct_chk_neqtol_dbl permit using an
+   absolute tolerance different than DBL_EPILSON.
 
 Whats new in FCTX 1.6.1
 -----------------------

--- a/doc/usr/source/api_fct.rst
+++ b/doc/usr/source/api_fct.rst
@@ -342,6 +342,12 @@ These are used to verify that a condition is true. They are executed within
     equality is done based on an absolute floating point difference less than
     the *DBL_EPISLON* defined in the standard <float.h> file.
 
+.. c:function:: fct_chk_eqtol_dbl(a, b, tol) 
+
+    *New in FCTX 1.6.2*. Causes a test failure if *a* != *b*. Testing for
+    equality is done based on an absolute floating point difference less than
+    *tol*.
+
 .. c:function:: fct_chk_eq_int(a, b)
 
     *New in FCTX 1.1*. Causes a test failure if *a* != *b*. Testing for
@@ -415,6 +421,12 @@ These are used to verify that a condition is true. They are executed within
     *New in FCTX 1.1*. Causes a test failure if *a* == *b*. Testing for
     inequality is done based on an absolute floating point difference that is
     NOT less than the *DBL_EPISLON* defined in the standard <float.h> file. 
+
+.. c:function:: fct_chk_neqtol_dbl(a, b, tol) 
+
+    *New in FCTX 1.6.2*. Causes a test failure if *a* == *b*. Testing for
+    inequality is done based on an absolute floating point difference that is
+    NOT less than the *tol*.
 
 .. c:function:: fct_chk_neq_int(a, b)
 

--- a/include/fct.h
+++ b/include/fct.h
@@ -3688,6 +3688,30 @@ with. If we fail a setup up, then we go directly to a teardown mode. */
         )
 
 
+#define fct_chk_eqtol_dbl(V1, V2, TOL) \
+    fct_xchk(\
+        ((int)(fabs((V1)-(V2)) < (TOL))),\
+        "chk_eq_dbl: %.*g != %.*g to tol %g",\
+        (DBL_DIG + 2),\
+        (V1),\
+        (DBL_DIG + 2),\
+        (V2),\
+        (TOL)\
+        )
+
+
+#define fct_chk_neqtol_dbl(V1, V2, TOL) \
+    fct_xchk(\
+        ((int)(fabs((V1)-(V2)) >= (TOL))),\
+        "chk_neq_dbl: %.*g == %.*g to tol %g",\
+        (DBL_DIG + 2),\
+        (V1),\
+        (DBL_DIG + 2),\
+        (V2),\
+        (TOL)\
+        )
+
+
 #define fct_chk_eq_str(V1, V2) \
     fct_xchk(fctstr_eq((V1), (V2)),\
           "chk_eq_str: '%s' != '%s'",\

--- a/tests/test_chk_types.c
+++ b/tests/test_chk_types.c
@@ -60,6 +60,18 @@ FCT_BGN()
     }
     FCT_QTEST_END();
 
+    FCT_QTEST_BGN(chk_dbl_eqtol)
+    {
+        fct_chk_eqtol_dbl(6123.2313,6123.2313,DBL_EPSILON);
+    }
+    FCT_QTEST_END();
+
+    FCT_QTEST_BGN(chk_dbl_neqtol)
+    {
+        fct_chk_neqtol_dbl(1.11111, 1.1,DBL_EPSILON);
+    }
+    FCT_QTEST_END();
+
     FCT_QTEST_BGN(chk_str_eq)
     {
         fct_chk_eq_str("a", "a");


### PR DESCRIPTION
Two small commits that improve the usability of fct_chk_eq_dbl and neq_dbl.  The first increases the displayed output.  The second adds a new fct_chk_eqtol_dbl taking a third tolerance argument as well as a similar neqtol_dbl.
