### PR TITLE
Fix Visual Studio 2019 warnings

### DIFF
--- a/examples/custom_logger/custom_logger_fct.h
+++ b/examples/custom_logger/custom_logger_fct.h
@@ -86,21 +86,21 @@ static void
 custlog__on_test_suite_end(fct_logger_i *l, fct_logger_evt_t const *e)
 {
     fct_ts_t const *test_suite = e->ts;
-    int test_cnt = fct_ts__tst_cnt(test_suite);
-    int passed_test_cnt = fct_ts__tst_cnt(test_suite);
-    int failed_test_cnt = test_cnt - passed_test_cnt;
+    size_t test_cnt = fct_ts__tst_cnt(test_suite);
+    size_t passed_test_cnt = fct_ts__tst_cnt(test_suite);
+    size_t failed_test_cnt = test_cnt - passed_test_cnt;
     (void)l;
     printf("on_test_suite_end:\n"
            "    -          name: %s\n"
            "    -      duration: %f ms\n"
-           "    -  tests passed: %d\n"
-           "    -  tests failed: %d\n"
-           "    -        checks: %lu\n",
+           "    -  tests passed: %zu\n"
+           "    -  tests failed: %zu\n"
+           "    -        checks: %zu\n",
            fct_ts__name(test_suite),
            fct_ts__duration(test_suite),
            passed_test_cnt,
            failed_test_cnt,
-           (unsigned long) fct_ts__chk_cnt(test_suite)
+           fct_ts__chk_cnt(test_suite)
           );
 }
 

--- a/include/fct.h
+++ b/include/fct.h
@@ -332,9 +332,12 @@ fctstr_clone_lower(char const *s)
     }
     klen = strlen(s)+1;
     k = (char*)malloc(sizeof(char)*klen+1);
-    for ( i=0; i != klen; ++i )
+    if ( k != NULL )
     {
-        k[i] = (char)tolower(s[i]);
+        for ( i=0; i != klen; ++i )
+        {
+            k[i] = (char)tolower(s[i]);
+        }
     }
     return k;
 }
@@ -395,7 +398,7 @@ http://publications.gbdirect.co.uk/c_book/chapter5/character_handling.html
 static int
 fctstr_eq(char const *s1, char const *s2)
 {
-    if ( s1 == s2 )
+    if ( ( s1 == NULL && s2 == NULL ) || s1 == s2 )
     {
         return 1;
     }
@@ -3051,7 +3054,7 @@ fct_junit_logger__on_test_suite_end(
     FCT_SWITCH_STDERR_TO_STDERR();
 
     /* opening testsuite tag */
-    printf("\t<testsuite errors=\"%lu\" failures=\"0\" tests=\"%lu\" "
+    printf("\t<testsuite errors=\"%zu\" failures=\"0\" tests=\"%lu\" "
            "name=\"%s\" time=\"%.4f\">\n",
            (unsigned long)   fct_ts__tst_cnt(ts)
            - fct_ts__tst_cnt_passed(ts),
@@ -3826,6 +3829,22 @@ _fct_chk_full_str(char const *s)
     fct_xchk(\
         ((V1) != (V2)),\
         "chq_neq_int: %d == %d",\
+        (V1),\
+        (V2)\
+        )
+
+#define fct_chk_eq_size_t(V1, V2) \
+    fct_xchk(\
+        ((V1) == (V2)),\
+        "chq_eq_size_t: %zu != %zu",\
+        (V1),\
+        (V2)\
+        )
+
+#define fct_chk_neq_size_t(V1, V2) \
+    fct_xchk(\
+        ((V1) != (V2)),\
+        "chq_neq_size_t: %zu == %zu",\
         (V1),\
         (V2)\
         )

--- a/tests/test_clp.c
+++ b/tests/test_clp.c
@@ -205,13 +205,13 @@ FCT_BGN()
                                       };
             int test_argc =4;
             int is_error =0;
-            int param_cnt =0;
+            size_t param_cnt =0;
 
             fct_clp__parse(&clp, test_argc, test_argv);
             is_error = fct_clp__is_error(&clp);
             fct_chk( !is_error );
             param_cnt = fct_clp__param_cnt(&clp);
-            fct_chk_eq_int( param_cnt, 3);
+            fct_chk_eq_size_t( param_cnt, 3);
 
             fct_chk( fct_clp__is_param(&clp, "parama") );
             fct_chk( !fct_clp__is_param(&clp, "funk") );

--- a/tests/test_start_other_than_main.c
+++ b/tests/test_start_other_than_main.c
@@ -22,7 +22,7 @@ _start_test(int argCount, char *argVariables[])
     FCT_QTEST_END();
 
     FCT_FINAL();
-    return FCT_NUM_FAILED();
+    return (int) FCT_NUM_FAILED();
 }
 
 int


### PR DESCRIPTION
This changes fixes sevearl warnings triggered by Visual Studio
2019. These are largerly due to 64bit size_t and extended static
analysis provided by newer revisions of intellisense. Instead
of using %lu, use %zu for size_t variables. Add a couple casts
where required. Finally, fix an issue where intellisense gets
tripped up by not considering that two null compared pointers would
be equivalent.